### PR TITLE
Fixes issue where opencv.rb cannot be installed from the provisioner

### DIFF
--- a/Formula/opencv.rb
+++ b/Formula/opencv.rb
@@ -21,8 +21,6 @@ class Opencv < Formula
   depends_on "openexr"
   depends_on "tbb"
 
-  needs :cxx11
-
   resource "contrib" do
     url "https://github.com/opencv/opencv_contrib/archive/3.4.0.tar.gz"
     sha256 "699ab3eee7922fbd3e8f98c68e6d16a1d453b20ef364e76172e56466dc9c16cd"


### PR DESCRIPTION
Updating to match the official opencv.rb Formula where it no longer does the check.