### PR TITLE
Update CCDEV brew formula to find bottle

### DIFF
--- a/Formula/qt.rb
+++ b/Formula/qt.rb
@@ -11,6 +11,7 @@ class Qt < Formula
   head "https://code.qt.io/qt/qt5.git", :branch => "dev", :shallow => false
 
   bottle do
+    root_url "https://homebrew.bintray.com/bottles/"
     cellar :any
     sha256 "d96ef428caa3b82d52039e9b7a0c768fbd70103f35b4b87989d01b3370b1e8c5" => :mojave
     sha256 "0b3487813eac66f3e9637fdf1ec02a054e2be9bfbb03b467798c07186fa9a19c" => :high_sierra


### PR DESCRIPTION
Set root URL so homebrew doesn't try to install bottle from nonexistent location. I don't see anyone else from the Case Production team listed as potential reviewers, so I'm sending to Nick and Charlie.